### PR TITLE
fix RabbitMQ container restart bug

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,15 +1,14 @@
 smsworks:
   build: .
   links:
-    - queue
+    - rabbitmq
   environment:
     TWILIO_SID:
     TWILIO_TOKEN:
     TWILIO_NUMBERS:
-queue:
+rabbitmq:
   image: rabbitmq:3.4.3-management
   ports:
-    - "5672"
-    - "15672"
-  environment:
-    RABBITMQ_NODENAME: sms_works
+    - 5672
+    - 15672
+  hostname: rabbitmq

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,6 @@ smsworks:
 rabbitmq:
   image: rabbitmq:3.4.3-management
   ports:
-    - 5672
-    - 15672
+    - "5672"
+    - "15672"
   hostname: rabbitmq

--- a/resources/config.edn
+++ b/resources/config.edn
@@ -1,8 +1,6 @@
-{
- :twilio {:sid #resource-config/env "TWILIO_SID"
+{:twilio {:sid #resource-config/env "TWILIO_SID"
           :token #resource-config/env "TWILIO_TOKEN"
           :numbers #resource-config/edn #resource-config/env "TWILIO_NUMBERS"}
- :rabbit-mq {:connection {:host #resource-config/env "QUEUE_PORT_5672_TCP_ADDR"
-                          :port #resource-config/edn #resource-config/env "QUEUE_PORT_5672_TCP_PORT"}
-             :queue "sms"}
-}
+ :rabbit-mq {:connection {:host #resource-config/env "RABBITMQ_PORT_5672_TCP_ADDR"
+                          :port #resource-config/edn #resource-config/env "RABBITMQ_PORT_5672_TCP_PORT"}
+             :queue "sms"}}


### PR DESCRIPTION
Also changes alias to "rabbitmq" for the same reason as everywhere
else (more precise, yadda yadda yadda).

Assigning @bwreid.