### PR TITLE
[TH] upgrade to newest twilio-api version

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -7,7 +7,7 @@
                  [org.clojure/tools.logging "0.3.1"]
                  [ch.qos.logback/logback-classic "1.1.3"]
                  [turbovote.resource-config "0.1.4"]
-                 [twilio-api "1.0.0"]
+                 [twilio-api "1.0.1"]
                  [com.novemberain/langohr "3.2.0"]]
   :main ^:skip-aot sms-works.core
   :target-path "target/%s"


### PR DESCRIPTION
Upgrade to newest twilio-api version which hits the non-deprecated twilio api which removes our 160 character limit.

Related to the work to demo [this](https://www.pivotaltracker.com/story/show/100581522), but not really on it's own card.

Wesley, would you mind taking a look? @bwreid 